### PR TITLE
Enable bug report: template, run script --debug, README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+A clear description of what went wrong.
+
+## To reproduce
+1. Steps to reproduce (e.g. "Open channels, click room X, send a message")
+2. ...
+
+## Expected behavior
+What you expected to happen.
+
+## Environment
+- **OS:** (e.g. Windows 11, Ubuntu 24.04, Raspberry Pi OS)
+- **Transport:** (Serial / TCP / BLE / SPI)
+- **Radio/firmware:** (if known)
+- **Python:** `uv run python --version`
+- **Node:** `node --version` (if frontend-related)
+
+## App logs
+Please paste logs from the app (backend/terminal output). If possible, run with debug logging first.
+
+**How to run with debug:**
+
+- **Using the run script:**  
+  `./scripts/run_remoterm.sh --debug --host 0.0.0.0 --port 8000`
+
+- **Or with uvicorn directly:**  
+  `MESHCORE_LOG_LEVEL=DEBUG uv run uvicorn app.main:app --host 0.0.0.0 --port 8000`
+
+Then paste the relevant log output below (include the lines around when the bug occurred):
+
+```
+(paste log output from the app here)
+```
+
+## Additional context
+Screenshots, config snippets (redact secrets), or other details that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/README.md
+++ b/README.md
@@ -388,4 +388,4 @@ To start the server with debug logging:
 MESHCORE_LOG_LEVEL=DEBUG uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
-Please include the relevant debug log output when filing an issue on GitHub.
+**Submit a bug:** [Open an issue](https://github.com/codemonkeybr/meshcore-pi-companion/issues/new) and include the relevant debug log output. Use the "Bug report" template for a structured report.

--- a/scripts/run_remoteterm.sh
+++ b/scripts/run_remoteterm.sh
@@ -4,12 +4,31 @@
 # separately (e.g. via scripts/install_remoterm_pi.sh).
 #
 # Usage:
-#   ./scripts/run_remoterm.sh [uvicorn args...]
-# Example:
+#   ./scripts/run_remoterm.sh [options] [uvicorn args...]
+#
+# Options:
+#   --debug, -d    Set MESHCORE_LOG_LEVEL=DEBUG (default: INFO)
+#
+# Examples:
 #   ./scripts/run_remoterm.sh --host 0.0.0.0 --port 8000
+#   ./scripts/run_remoterm.sh --debug --host 0.0.0.0 --port 8000
 
 set -e
 cd "$(dirname "$0")/.."
 export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$(pwd)"
 
-exec uvicorn app.main:app "$@"
+UV_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --debug|-d)
+      export MESHCORE_LOG_LEVEL=DEBUG
+      shift
+      ;;
+    *)
+      UV_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec uvicorn app.main:app "${UV_ARGS[@]}"


### PR DESCRIPTION
Add GitHub Issue template for bug reports (with app logs and how to run with debug).
Add --debug / -d to scripts/run_remoterm.sh for MESHCORE_LOG_LEVEL=DEBUG; default stays INFO.
Update README with a link to open an issue and use the Bug report template.