### PR TITLE
Fix repeater login 500: use EventType.LOGIN_SUCCESS (fixes #4

### DIFF
--- a/app/backends/spi_backend.py
+++ b/app/backends/spi_backend.py
@@ -662,7 +662,7 @@ class SpiBackend(RadioBackend):
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found"})
         result = await self._node.send_login(contact_name, password)
-        return _Event(EventType.LOGIN_RESPONSE, result)
+        return _Event(EventType.LOGIN_SUCCESS, result)
 
     async def req_status_sync(
         self,


### PR DESCRIPTION
## Summary
Fixes **#4** (login into repeater with guest button returns 500).
## Cause
`app/backends/spi_backend.py` `send_login()` returned `_Event(EventType.LOGIN_RESPONSE, result)`, but the `meshcore` package does not define `LOGIN_RESPONSE` — it provides `LOGIN_SUCCESS` and `LOGIN_FAILED` instead. That raised `AttributeError` and resulted in a 500 on `POST .../repeater/login`.
## Change
Use `EventType.LOGIN_SUCCESS` when returning the successful login result. The repeater router only treats `EventType.ERROR` as failure, so non-ERROR (including `LOGIN_SUCCESS`) is correct for success.
## Testing
- `tests/test_repeater_routes.py` (including `TestRepeaterLogin::test_success`) passes.
- All quality checks (ruff, pyright, pytest, frontend tests + build) pass.