### PR TITLE
Consolidate identity_key into config.yaml (remove spi_config.json)

### DIFF
--- a/app/spi_identity.py
+++ b/app/spi_identity.py
@@ -2,13 +2,12 @@
 
 Handles generation, persistence, and loading of the 32-byte seed that
 serves as the node's mesh identity.  The seed is stored base64-encoded
-inside ``data/spi_config.json`` (alongside radio/hardware settings).
+as ``identity_key`` inside ``data/config.yaml`` (alongside radio/hardware settings).
 """
 
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import os
 from pathlib import Path
@@ -16,7 +15,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG_PATH = Path("data/spi_config.json")
+DEFAULT_CONFIG_PATH = Path("data/config.yaml")
 
 
 def _ensure_dir(path: Path) -> None:
@@ -29,18 +28,28 @@ def generate_identity_seed() -> bytes:
 
 
 def load_spi_config(path: Path = DEFAULT_CONFIG_PATH) -> dict[str, Any]:
-    """Load the SPI config file, returning an empty dict if it doesn't exist."""
+    """Load the config file, returning an empty dict if it doesn't exist."""
+    import yaml  # lazy — only available when [spi] extra is installed
+
     if not path.exists():
         return {}
     with open(path) as f:
-        return json.load(f)
+        return yaml.safe_load(f) or {}
 
 
 def save_spi_config(config: dict[str, Any], path: Path = DEFAULT_CONFIG_PATH) -> None:
-    """Persist *config* to the SPI config file."""
+    """Persist *config* to the config file, merging with any existing content."""
+    import yaml  # lazy — only available when [spi] extra is installed
+
     _ensure_dir(path)
+    # Load existing file to preserve all other keys (node, radio, hardware, etc.)
+    existing: dict[str, Any] = {}
+    if path.exists():
+        with open(path) as f:
+            existing = yaml.safe_load(f) or {}
+    existing.update(config)
     with open(path, "w") as f:
-        json.dump(config, f, indent=2)
+        yaml.safe_dump(existing, f, sort_keys=False)
     logger.info("SPI config saved to %s", path)
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -67,3 +67,6 @@ hardware:
 # Logging level: DEBUG, INFO, WARNING, ERROR
 logging:
   level: INFO
+
+# Node identity — auto-generated on first run; do not edit by hand.
+# identity_key: <base64-encoded 32-byte seed>

--- a/tests/test_spi_backend.py
+++ b/tests/test_spi_backend.py
@@ -83,7 +83,7 @@ class TestSpiIdentity:
     def test_load_or_create_identity_creates_new(self, tmp_path):
         from app.spi_identity import load_or_create_identity, load_spi_config
 
-        cfg_path = tmp_path / "spi_config.json"
+        cfg_path = tmp_path / "config.yaml"
         seed = load_or_create_identity(cfg_path)
         assert len(seed) == 32
 
@@ -95,7 +95,7 @@ class TestSpiIdentity:
     def test_load_or_create_identity_loads_existing(self, tmp_path):
         from app.spi_identity import load_or_create_identity, save_spi_config
 
-        cfg_path = tmp_path / "spi_config.json"
+        cfg_path = tmp_path / "config.yaml"
         original_seed = os.urandom(32)
         save_spi_config(
             {"identity_key": base64.b64encode(original_seed).decode()},
@@ -108,14 +108,14 @@ class TestSpiIdentity:
     def test_import_identity_validates_length(self, tmp_path):
         from app.spi_identity import import_identity
 
-        cfg_path = tmp_path / "spi_config.json"
+        cfg_path = tmp_path / "config.yaml"
         with pytest.raises(ValueError, match="32 bytes"):
             import_identity(b"too-short", cfg_path)
 
     def test_export_identity_round_trip(self, tmp_path):
         from app.spi_identity import export_identity, import_identity
 
-        cfg_path = tmp_path / "spi_config.json"
+        cfg_path = tmp_path / "config.yaml"
         seed = os.urandom(32)
         import_identity(seed, cfg_path)
         assert export_identity(cfg_path) == seed


### PR DESCRIPTION
## Summary

Closes #20

- Removes `data/spi_config.json` — the separate JSON file that only stored `identity_key`
- Moves `identity_key` storage into `data/config.yaml` alongside all other node/radio/hardware settings
- `save_spi_config` now merges into the existing YAML rather than overwriting, preserving all other config keys
- Updated `DEFAULT_CONFIG_PATH` in `spi_identity.py` from `data/spi_config.json` → `data/config.yaml`
- Added `identity_key` comment to `config.yaml.example` so users know the field exists
- Updated all `TestSpiIdentity` tests to use `config.yaml` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)