### PR TITLE
fix: align LetsMesh packet format with spec and populate SPI radio info

### DIFF
--- a/app/backends/spi_backend.py
+++ b/app/backends/spi_backend.py
@@ -223,6 +223,10 @@ class SpiBackend(RadioBackend):
             "lat": 0.0,
             "lon": 0.0,
             "tx_power": tx_power,
+            "radio_freq": frequency / 1_000_000,
+            "radio_bw": bandwidth / 1_000,
+            "radio_sf": spreading_factor,
+            "radio_cr": coding_rate,
         }
         self._connected = True
         logger.info("SPI backend online — node %s (%s…)", node_name, pub_hex[:12])

--- a/app/fanout/community_mqtt.py
+++ b/app/fanout/community_mqtt.py
@@ -225,14 +225,16 @@ def _format_raw_packet(data: dict[str, Any], device_name: str, public_key_hex: s
         "type": "PACKET",
         "direction": "rx",
         "time": current_time.strftime("%H:%M:%S"),
-        "date": current_time.strftime("%d/%m/%Y"),
+        "date": current_time.strftime("%-d/%-m/%Y"),
         "len": str(len(raw_bytes)),
         "packet_type": packet_type,
         "route": route,
         "payload_len": payload_len,
-        "raw": raw_hex.upper(),
+        "raw": raw_hex,
         "SNR": snr,
         "RSSI": rssi,
+        "score": "0",
+        "duration": "0",
         "hash": packet_hash,
     }
 

--- a/tests/test_community_mqtt.py
+++ b/tests/test_community_mqtt.py
@@ -222,7 +222,7 @@ class TestPacketFormatConversion:
 
         assert result["origin"] == "TestNode"
         assert result["origin_id"] == "AABBCCDD" * 8
-        assert result["raw"] == "0A1B2C3D"
+        assert result["raw"] == "0a1b2c3d"
         assert result["SNR"] == "5.5"
         assert result["RSSI"] == "-90"
         assert result["type"] == "PACKET"


### PR DESCRIPTION
## Summary

- **Missing packet fields**: Added `score` (`"0"`) and `duration` (`"0"`) to the LetsMesh packet payload — both required by the meshcore-packet-capture schema but previously absent.
- **Date format**: Fixed `%d/%m/%Y` (leading zeros, e.g. `05/04/2026`) → `%-d/%-m/%Y` (no leading zeros, e.g. `5/4/2026`) to match the `D/M/YYYY` reference format.
- **`raw` field case**: Removed `.upper()` so the hex string is passed through as-is, matching the lowercase output of the reference implementation.
- **SPI radio info in status heartbeat**: `SpiBackend._self_info` was never populated with `radio_freq`, `radio_bw`, `radio_sf`, `radio_cr`, so `_build_radio_info()` always fell back to `"0,0,0,0"` in SPI mode. These are now stored (in MHz / kHz to match the client backend unit convention) so the actual radio config is sent in the LetsMesh status message.

## Test plan

- [x] All 1206 existing tests pass (`pytest -x -q`)
- [x] `tests/test_community_mqtt.py` updated to reflect lowercase `raw` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)