### PR TITLE
feat: download from GitHub Releases and auto-generate backend bundles on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+# Build a backend release bundle on push to main.
+#
+# Reads the semantic version from pyproject.toml, creates (if missing) a
+# GitHub Release tagged v{version}, and uploads:
+#   - remoteterm-backend-{version}.tar.gz  (backend bundle)
+#   - remoteterm-backend-{version}.tar.gz.sha256  (checksum for integrity)
+#
+# The frontend is intentionally excluded; it remains a separate asset under the
+# frontend-latest release (see frontend-build.yml).
+name: Release build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          version="$(grep -E '^version' pyproject.toml | head -n1 | cut -d'"' -f2)"
+          if [ -z "$version" ]; then
+            echo "Could not parse version from pyproject.toml" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "Parsed version: $version (tag: v$version)"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $tag already exists; skipping creation."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build backend bundle
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          artifact="remoteterm-backend-${version}.tar.gz"
+          tar czf "$artifact" \
+            --exclude='./.git' \
+            --exclude='./.github' \
+            --exclude='./.venv' \
+            --exclude='./frontend' \
+            --exclude='./node_modules' \
+            --exclude='./__pycache__' \
+            --exclude='*/__pycache__' \
+            --exclude='*.pyc' \
+            --exclude='./.pytest_cache' \
+            --exclude='./.ruff_cache' \
+            --exclude='./.mypy_cache' \
+            --exclude='./data/meshcore.db*' \
+            --exclude='./LICENSE.md' \
+            --exclude='./README.md' \
+            --exclude='./CLAUDE.md' \
+            --exclude='./AGENTS.md' \
+            --exclude="./$artifact" \
+            .
+          sha256sum "$artifact" > "${artifact}.sha256"
+          ls -lh "$artifact" "${artifact}.sha256"
+          # Sanity check: bundle must contain scripts/ and pyproject.toml.
+          tar tzf "$artifact" | grep -q '^\./scripts/manage_remoterm.sh$'
+          tar tzf "$artifact" | grep -q '^\./pyproject.toml$'
+
+      - name: Upload backend artifact (Actions)
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: remoteterm-backend-${{ steps.version.outputs.version }}
+          path: |
+            remoteterm-backend-${{ steps.version.outputs.version }}.tar.gz
+            remoteterm-backend-${{ steps.version.outputs.version }}.tar.gz.sha256
+          retention-days: 30
+
+      - name: Create GitHub Release and upload assets
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          version="${{ steps.version.outputs.version }}"
+          gh release create "$tag" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "RemoteTerm Backend $tag" \
+            --generate-notes
+          gh release upload "$tag" \
+            "remoteterm-backend-${version}.tar.gz" \
+            "remoteterm-backend-${version}.tar.gz.sha256" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/scripts/get-remoteterm.sh
+++ b/scripts/get-remoteterm.sh
@@ -1,55 +1,133 @@
 #!/usr/bin/env bash
 # RemoteTerm bootstrap installer.
 #
-# Downloads the RemoteTerm source and launches the interactive installer (manage_remoterm.sh).
+# Downloads the RemoteTerm backend release artifact from GitHub Releases and
+# launches the interactive installer (manage_remoterm.sh).
 #
 # IMPORTANT: run with bash <(curl ...) to preserve the TTY required by the interactive menus:
 #
 #   bash <(curl -fsSL https://raw.githubusercontent.com/codemonkeybr/meshcore-pi-companion/main/scripts/get-remoteterm.sh)
 #
 # Environment overrides:
-#   REMOTETERM_BRANCH=main          Git branch to clone (default: main)
+#   RELEASE_VERSION=latest          Release tag to install (default: latest)
+#                                   Examples: "latest", "v3.2.0"
+#   REMOTETERM_REPO=codemonkeybr/meshcore-pi-companion
+#                                   GitHub repo (owner/name) hosting the releases
 #   ALLOW_NON_PI=1                  Skip Raspberry Pi check (for testing only)
 #   FRONTEND_RELEASE_URL=...        Override prebuilt frontend zip URL
 
 set -euo pipefail
 
-REPO_URL="https://github.com/codemonkeybr/meshcore-pi-companion"
-BRANCH="${REMOTETERM_BRANCH:-main}"
+REPO="${REMOTETERM_REPO:-codemonkeybr/meshcore-pi-companion}"
+RELEASE_VERSION="${RELEASE_VERSION:-latest}"
+GITHUB_API="https://api.github.com"
+GITHUB_RELEASES="https://github.com/${REPO}/releases"
 TMP_DIR="$(mktemp -d /tmp/remoteterm-install-XXXXXX)"
 
 # Clean up temp dir on error; exec replaces the process so this won't fire on success.
 trap 'echo "Bootstrap failed; cleaning up..." >&2; rm -rf "$TMP_DIR"' ERR
 
 echo "=== RemoteTerm Bootstrap ==="
-echo "Branch : $BRANCH"
-echo "Temp   : $TMP_DIR"
+echo "Repo    : $REPO"
+echo "Version : $RELEASE_VERSION"
+echo "Temp    : $TMP_DIR"
 echo ""
 
-# Download source
-if command -v git &>/dev/null; then
-  echo "Cloning $REPO_URL (branch: $BRANCH)..."
-  git clone --depth=1 --branch "$BRANCH" "$REPO_URL" "$TMP_DIR/src"
-elif command -v curl &>/dev/null; then
-  echo "git not found — downloading tarball via curl..."
-  curl -fsSL "$REPO_URL/archive/refs/heads/${BRANCH}.tar.gz" \
-    | tar -xz -C "$TMP_DIR"
-  mv "$TMP_DIR"/meshcore-pi-companion-* "$TMP_DIR/src"
-elif command -v wget &>/dev/null; then
-  echo "git not found — downloading tarball via wget..."
-  wget -q -O- "$REPO_URL/archive/refs/heads/${BRANCH}.tar.gz" \
-    | tar -xz -C "$TMP_DIR"
-  mv "$TMP_DIR"/meshcore-pi-companion-* "$TMP_DIR/src"
-else
-  echo "Error: need git, curl, or wget to download RemoteTerm." >&2
+if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
+  echo "Error: need curl or wget to download the RemoteTerm release." >&2
   exit 1
 fi
 
+# http_fetch URL OUTFILE -- fetch URL to OUTFILE with progress (or silent if no TTY).
+http_fetch() {
+  local url="$1" out="$2"
+  if command -v curl &>/dev/null; then
+    if [ -t 1 ]; then
+      curl -fL --progress-bar -o "$out" "$url"
+    else
+      curl -fsSL -o "$out" "$url"
+    fi
+  else
+    wget -q --show-progress -O "$out" "$url"
+  fi
+}
+
+# http_get_text URL -- print URL body to stdout, silent (used for API queries).
+http_get_text() {
+  local url="$1"
+  if command -v curl &>/dev/null; then
+    curl -fsSL "$url"
+  else
+    wget -q -O- "$url"
+  fi
+}
+
+resolve_version() {
+  local version="$1"
+  if [ "$version" != "latest" ]; then
+    echo "$version"
+    return
+  fi
+  local body
+  if ! body="$(http_get_text "${GITHUB_API}/repos/${REPO}/releases/latest")"; then
+    echo "Error: failed to query GitHub Releases API for the latest version." >&2
+    echo "Check network, GitHub availability, and API rate limits, or set RELEASE_VERSION=vX.Y.Z explicitly." >&2
+    exit 1
+  fi
+  # Minimal tag_name extraction without jq: take first "tag_name": "..." line.
+  local tag
+  tag="$(printf '%s' "$body" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+  if [ -z "$tag" ]; then
+    echo "Error: could not parse tag_name from GitHub API response." >&2
+    exit 1
+  fi
+  echo "$tag"
+}
+
+echo "Resolving release version..."
+TAG="$(resolve_version "$RELEASE_VERSION")"
+# Strip leading "v" for the artifact filename (remoteterm-backend-3.2.0.tar.gz).
+SEMVER="${TAG#v}"
+ARTIFACT="remoteterm-backend-${SEMVER}.tar.gz"
+CHECKSUM="${ARTIFACT}.sha256"
+ARTIFACT_URL="${GITHUB_RELEASES}/download/${TAG}/${ARTIFACT}"
+CHECKSUM_URL="${GITHUB_RELEASES}/download/${TAG}/${CHECKSUM}"
+
+echo "Release : $TAG"
+echo "Asset   : $ARTIFACT"
+echo ""
+
+echo "Downloading release artifact..."
+if ! http_fetch "$ARTIFACT_URL" "$TMP_DIR/$ARTIFACT"; then
+  echo "Error: failed to download $ARTIFACT_URL" >&2
+  echo "Possible causes: invalid version tag, network failure, GitHub rate limit." >&2
+  exit 1
+fi
+
+echo "Downloading checksum..."
+if http_fetch "$CHECKSUM_URL" "$TMP_DIR/$CHECKSUM" 2>/dev/null; then
+  echo "Verifying SHA256 checksum..."
+  (cd "$TMP_DIR" && sha256sum -c "$CHECKSUM") || {
+    echo "Error: checksum verification failed for $ARTIFACT." >&2
+    exit 1
+  }
+else
+  echo "Warning: no checksum file at $CHECKSUM_URL; skipping integrity verification." >&2
+fi
+
+echo "Extracting release..."
+mkdir -p "$TMP_DIR/src"
+tar -xzf "$TMP_DIR/$ARTIFACT" -C "$TMP_DIR/src"
+
 MANAGER="$TMP_DIR/src/scripts/manage_remoterm.sh"
+if [ ! -f "$MANAGER" ]; then
+  echo "Error: $MANAGER missing after extraction — release artifact is malformed." >&2
+  exit 1
+fi
 chmod +x "$MANAGER"
 
 echo ""
-echo "Source downloaded. Launching installer..."
+echo "Release extracted. Launching installer..."
 echo "(Source files are in $TMP_DIR/src — safe to delete after install.)"
 echo ""
 
@@ -58,10 +136,12 @@ if [ "${EUID:-$(id -u)}" -ne 0 ]; then
   exec sudo \
     ALLOW_NON_PI="${ALLOW_NON_PI:-0}" \
     FRONTEND_RELEASE_URL="${FRONTEND_RELEASE_URL:-}" \
+    RELEASE_VERSION="$TAG" \
     bash "$MANAGER" install
 else
   exec \
     ALLOW_NON_PI="${ALLOW_NON_PI:-0}" \
     FRONTEND_RELEASE_URL="${FRONTEND_RELEASE_URL:-}" \
+    RELEASE_VERSION="$TAG" \
     bash "$MANAGER" install
 fi

--- a/scripts/manage_remoterm.sh
+++ b/scripts/manage_remoterm.sh
@@ -10,6 +10,8 @@
 # Environment:
 #   ALLOW_NON_PI=1     Skip Raspberry Pi device-tree check (for debugging only).
 #   FRONTEND_RELEASE_URL  Override prebuilt frontend zip URL (default: meshcore-pi-companion frontend-latest).
+#   REMOTETERM_REPO=codemonkeybr/meshcore-pi-companion  GitHub repo for release downloads.
+#   RELEASE_VERSION=latest  Release tag for upgrade (overridden by --version flag).
 
 set -euo pipefail
 
@@ -22,7 +24,8 @@ ENV_FILE="$CONFIG_ENV_DIR/environment"
 SERVICE_USER="remoteterm"
 SERVICE_NAME="remoteterm"
 SERVICE_USER_HOME="/var/lib/remoteterm"
-DEFAULT_FRONTEND_URL="${FRONTEND_RELEASE_URL:-https://github.com/codemonkeybr/meshcore-pi-companion/releases/download/frontend-latest/frontend-dist.zip}"
+REMOTETERM_REPO="${REMOTETERM_REPO:-codemonkeybr/meshcore-pi-companion}"
+DEFAULT_FRONTEND_URL="${FRONTEND_RELEASE_URL:-https://github.com/${REMOTETERM_REPO}/releases/download/frontend-latest/frontend-dist.zip}"
 
 # shellcheck disable=SC2034
 DIALOG=""
@@ -149,6 +152,107 @@ sync_source_upgrade() {
     echo "rsync is recommended for upgrade; install rsync or re-run install from a fresh copy." >&2
     sync_source_to_install
   fi
+}
+
+# http_get_text URL -- print URL body to stdout (silent, for API queries).
+http_get_text() {
+  local url="$1"
+  if command -v curl &>/dev/null; then
+    curl -fsSL "$url"
+  elif command -v wget &>/dev/null; then
+    wget -q -O- "$url"
+  else
+    echo "Error: need curl or wget." >&2
+    return 1
+  fi
+}
+
+# http_fetch URL OUTFILE -- download URL to OUTFILE.
+http_fetch() {
+  local url="$1" out="$2"
+  if command -v curl &>/dev/null; then
+    if [ -t 1 ]; then
+      curl -fL --progress-bar -o "$out" "$url"
+    else
+      curl -fsSL -o "$out" "$url"
+    fi
+  elif command -v wget &>/dev/null; then
+    wget -q --show-progress -O "$out" "$url"
+  else
+    echo "Error: need curl or wget." >&2
+    return 1
+  fi
+}
+
+# Resolve "latest" or a specific tag against the GitHub Releases API. Echoes the
+# concrete tag (e.g. "v3.2.0") on success.
+resolve_release_version() {
+  local version="$1"
+  if [ -z "$version" ] || [ "$version" = "latest" ]; then
+    local body
+    if ! body="$(http_get_text "https://api.github.com/repos/${REMOTETERM_REPO}/releases/latest")"; then
+      echo "Error: failed to query GitHub Releases API for the latest version." >&2
+      return 1
+    fi
+    local tag
+    tag="$(printf '%s' "$body" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+    if [ -z "$tag" ]; then
+      echo "Error: could not parse tag_name from GitHub API response." >&2
+      return 1
+    fi
+    echo "$tag"
+    return 0
+  fi
+  # Validate the tag exists by asking the API directly.
+  if ! http_get_text "https://api.github.com/repos/${REMOTETERM_REPO}/releases/tags/${version}" >/dev/null; then
+    echo "Error: release version '$version' not found in ${REMOTETERM_REPO}." >&2
+    return 1
+  fi
+  echo "$version"
+}
+
+# Download + extract a release tarball. Echoes the extracted source root path.
+# Usage: download_release_to_tmp TAG
+download_release_to_tmp() {
+  local tag="$1"
+  local semver="${tag#v}"
+  local artifact="remoteterm-backend-${semver}.tar.gz"
+  local checksum="${artifact}.sha256"
+  local base="https://github.com/${REMOTETERM_REPO}/releases/download/${tag}"
+  local tmp
+  tmp="$(mktemp -d /tmp/remoteterm-upgrade-XXXXXX)"
+
+  echo "Downloading $artifact ..." >&2
+  if ! http_fetch "${base}/${artifact}" "${tmp}/${artifact}"; then
+    echo "Error: failed to download ${base}/${artifact}" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  if http_fetch "${base}/${checksum}" "${tmp}/${checksum}" 2>/dev/null; then
+    echo "Verifying SHA256 checksum..." >&2
+    if ! (cd "$tmp" && sha256sum -c "$checksum" >/dev/null 2>&1); then
+      echo "Error: checksum verification failed for $artifact." >&2
+      rm -rf "$tmp"
+      return 1
+    fi
+  else
+    echo "Warning: no checksum file for $tag; skipping integrity verification." >&2
+  fi
+
+  mkdir -p "${tmp}/src"
+  if ! tar -xzf "${tmp}/${artifact}" -C "${tmp}/src"; then
+    echo "Error: failed to extract ${artifact}." >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  if [ ! -f "${tmp}/src/pyproject.toml" ]; then
+    echo "Error: release artifact missing pyproject.toml — malformed bundle." >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  echo "${tmp}/src"
 }
 
 create_service_user() {
@@ -383,6 +487,28 @@ do_install() {
 }
 
 do_upgrade() {
+  local requested_version="${RELEASE_VERSION:-latest}"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --version)
+        if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+          echo "Error: --version requires a value (e.g. --version v3.2.0)." >&2
+          exit 2
+        fi
+        requested_version="$2"
+        shift 2
+        ;;
+      --version=*)
+        requested_version="${1#--version=}"
+        shift
+        ;;
+      *)
+        echo "Error: unknown upgrade argument: $1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
   require_tty
   pick_dialog
   if [ "${EUID:-0}" -ne 0 ]; then
@@ -393,20 +519,46 @@ do_upgrade() {
     show_error "RemoteTerm is not installed."
     exit 1
   fi
-  if ! ask_yes_no "Confirm upgrade" "Upgrade RemoteTerm from:\n$SOURCE_ROOT\n\nto $INSTALL_DIR ?"; then
+
+  echo "Resolving release version ($requested_version)..."
+  local tag
+  if ! tag="$(resolve_release_version "$requested_version")"; then
+    show_error "Could not resolve release version '$requested_version'.\n\nCheck network access and verify the tag exists on\nhttps://github.com/${REMOTETERM_REPO}/releases"
+    exit 1
+  fi
+
+  local current_version
+  current_version="$(get_version)"
+  if ! ask_yes_no "Confirm upgrade" "Upgrade RemoteTerm:\n\n  current : $current_version\n  target  : $tag\n\nDownload release and install to $INSTALL_DIR ?"; then
     exit 0
   fi
+
+  local release_src
+  if ! release_src="$(download_release_to_tmp "$tag")"; then
+    show_error "Failed to download release $tag.\n\nSee terminal output for details."
+    exit 1
+  fi
+
   systemctl stop "$SERVICE_NAME" 2>/dev/null || true
   local backup_dir="/tmp/remoteterm_data_backup_$(date +%Y%m%d_%H%M%S)"
   if [ -d "$INSTALL_DIR/data" ]; then
     cp -a "$INSTALL_DIR/data" "$backup_dir" 2>/dev/null || true
   fi
+
+  # Point sync at the downloaded release tree; restore on exit so the script
+  # state stays consistent for any follow-up commands.
+  local prev_source_root="$SOURCE_ROOT"
+  SOURCE_ROOT="$release_src"
   sync_source_upgrade
+  SOURCE_ROOT="$prev_source_root"
+
   chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
   install_python_deps
   install_systemd_unit
   systemctl start "$SERVICE_NAME"
-  show_info "Upgrade" "Upgrade complete.\n\nData backup copy:\n$backup_dir"
+
+  rm -rf "$(dirname "$release_src")" 2>/dev/null || true
+  show_info "Upgrade" "Upgrade complete.\n\nInstalled: $tag\nData backup copy:\n$backup_dir"
 }
 
 do_uninstall() {
@@ -602,20 +754,24 @@ RemoteTerm Pi management (Raspberry Pi OS).
 Usage: $0 [command]
 
 Commands:
-  install     Full install (interactive transport selection)
-  upgrade     Sync from source tree to $INSTALL_DIR
-  uninstall   Remove service and install directory
-  config-spi  Run SPI wizard (setup_cli)
-  config-usb  Set USB serial device in $ENV_FILE
+  install             Full install (interactive transport selection)
+  upgrade [--version vX.Y.Z]
+                      Download release from GitHub and install to $INSTALL_DIR.
+                      Defaults to latest when --version is omitted.
+  uninstall           Remove service and install directory
+  config-spi          Run SPI wizard (setup_cli)
+  config-usb          Set USB serial device in $ENV_FILE
   start | stop | restart   systemd
-  status      Show status
-  help        This help
+  status              Show status
+  help                This help
 
 With no arguments, shows the interactive menu (requires a TTY).
 
 Environment:
   ALLOW_NON_PI=1
   FRONTEND_RELEASE_URL=...   Prebuilt frontend zip URL
+  REMOTETERM_REPO=owner/name GitHub repo for release downloads
+  RELEASE_VERSION=latest     Default release tag for upgrade
 EOF
 }
 
@@ -630,7 +786,8 @@ case "${1:-}" in
     exit 0
     ;;
   upgrade)
-    do_upgrade
+    shift
+    do_upgrade "$@"
     exit 0
     ;;
   uninstall)


### PR DESCRIPTION
## Summary

- **get-remoteterm.sh**: replaced git-clone bootstrap with GitHub Releases download. Resolves the latest (or pinned `RELEASE_VERSION`) tag via the GitHub API, downloads `remoteterm-backend-{version}.tar.gz`, verifies its SHA256 checksum, extracts to a temp dir, and execs `manage_remoterm.sh install`.
- **manage_remoterm.sh**: `upgrade` now downloads a release instead of syncing from a local source tree. Accepts `--version vX.Y.Z` to pin a specific release; defaults to the latest tag queried from the GitHub API. Unknown tags fail fast with a clear error message.
- **.github/workflows/release.yml** (new): triggers on push to `main` and `workflow_dispatch`. Reads the version from `pyproject.toml`, skips if the tag already exists, bundles the backend (`tar czf`) with all required excludes (frontend, `.git`, `.venv`, `__pycache__`, docs, etc.), generates a `.sha256` checksum, uploads both as a 30-day Actions artifact, and creates a versioned GitHub Release.

Closes #29.

## Test plan

- [ ] Merge a branch to `main` and confirm `release.yml` creates a `v{version}` GitHub Release with `remoteterm-backend-{version}.tar.gz` and its `.sha256`.
- [ ] Run the one-line installer on a fresh Raspberry Pi OS and verify the app installs and launches successfully.
- [ ] Run `sudo ./scripts/manage_remoterm.sh upgrade` (no flag) and confirm it downloads the latest release.
- [ ] Run `sudo ./scripts/manage_remoterm.sh upgrade --version v3.2.0` and confirm that exact version is installed.
- [ ] Confirm frontend artifact remains excluded from the backend bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)