### PR TITLE
fix: write tar bundle to /tmp to avoid file-changed race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
           artifact="remoteterm-backend-${version}.tar.gz"
-          tar czf "$artifact" \
+          tar czf "/tmp/$artifact" \
             --exclude='./.git' \
             --exclude='./.github' \
             --exclude='./.venv' \
@@ -71,8 +71,8 @@ jobs:
             --exclude='./README.md' \
             --exclude='./CLAUDE.md' \
             --exclude='./AGENTS.md' \
-            --exclude="./$artifact" \
             .
+          mv "/tmp/$artifact" .
           sha256sum "$artifact" > "${artifact}.sha256"
           ls -lh "$artifact" "${artifact}.sha256"
           # Sanity check: bundle must contain scripts/ and pyproject.toml.


### PR DESCRIPTION
## Summary

- Fixes the release workflow failure introduced after merging PR #30
- `tar` was archiving `.` while writing the output `.tar.gz` into the same directory, causing `tar: .: file changed as we read it` (exit 1)
- Fix: write the artifact to `/tmp/$artifact` first, then `mv` it back — eliminates the race and removes the need for the self-exclusion flag

Closes #31

## Test plan

- [ ] Merge to `main` and confirm the **Release build** workflow runs to completion
- [ ] Verify the `.tar.gz` and `.sha256` assets are attached to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)