### PR TITLE
fix: avoid broken pipe in tar sanity checks under pipefail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,9 @@ jobs:
           sha256sum "$artifact" > "${artifact}.sha256"
           ls -lh "$artifact" "${artifact}.sha256"
           # Sanity check: bundle must contain scripts/ and pyproject.toml.
-          tar tzf "$artifact" | grep -q '^\./scripts/manage_remoterm.sh$'
-          tar tzf "$artifact" | grep -q '^\./pyproject.toml$'
+          listing=$(tar tzf "$artifact")
+          echo "$listing" | grep -q '^\./scripts/manage_remoterm.sh$'
+          echo "$listing" | grep -q '^\./pyproject.toml$'
 
       - name: Upload backend artifact (Actions)
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- Follow-up to #32 — the `/tmp` fix resolved the first error but exposed a second failure
- `tar tzf "$artifact" | grep -q ...` causes `tar: stdout: write error` (exit 2) under `set -euo pipefail`: `grep -q` exits after the first match, closing the pipe, so `tar` gets SIGPIPE and exits non-zero
- Fix: capture the full listing into a shell variable once, then grep on that — no pipe, no broken pipe

Closes #31

## Test plan

- [ ] Merge to `main` and confirm the **Release build** workflow completes without error
- [ ] Verify `.tar.gz` and `.sha256` assets are attached to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)