### PR TITLE
ci: gate release build on All Quality passing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
-# Build a backend release bundle on push to main.
+# Build a backend release bundle after quality checks pass on main.
+#
+# Triggered by the "All Quality" workflow completing on main — the release job
+# only runs when quality succeeded, so a bad build can never produce an artifact.
 #
 # Reads the semantic version from pyproject.toml, creates (if missing) a
 # GitHub Release tagged v{version}, and uploads:
@@ -10,7 +13,9 @@
 name: Release build
 
 on:
-  push:
+  workflow_run:
+    workflows: ["All Quality"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -19,6 +24,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Changes `release.yml` trigger from `push: branches: [main]` to `workflow_run` on `All Quality` completing on `main`
- Adds an `if` condition on the release job so it only runs when quality **succeeded** (or when triggered manually via `workflow_dispatch`)
- A push to `main` that fails lint, type checks, or tests will never produce a release artifact

## Pipeline order after this change

```
push to main
  └── All Quality (backend-checks + frontend-checks)
        └── [on success] Release build
```

## Test plan

- [ ] Merge and push a commit to `main` — confirm Release build only starts after All Quality passes
- [ ] Verify a quality failure blocks the release job from running
- [ ] Confirm `workflow_dispatch` still triggers the release manually

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)