### PR TITLE
fix: suppress pip cache warning in manage_remoterm.sh

### DIFF
--- a/scripts/manage_remoterm.sh
+++ b/scripts/manage_remoterm.sh
@@ -281,11 +281,11 @@ fi
 # shellcheck disable=SC1091
 source .venv/bin/activate
 export PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}"
-pip install --upgrade pip wheel
+pip install --no-cache-dir --upgrade pip wheel
 max=5
 attempt=1
 while [ "$attempt" -le "$max" ]; do
-  if pip install --default-timeout="$PIP_DEFAULT_TIMEOUT" '.[spi]'; then
+  if pip install --no-cache-dir --default-timeout="$PIP_DEFAULT_TIMEOUT" '.[spi]'; then
     break
   fi
   if [ "$attempt" -eq "$max" ]; then


### PR DESCRIPTION
## Summary
- Added `--no-cache-dir` to both `pip install --upgrade pip wheel` and the retry loop `pip install '.[spi]'` calls in `scripts/manage_remoterm.sh`
- Eliminates pip cache-related warnings that appeared during install on Pi targets

## Test plan
- [ ] Run `manage_remoterm.sh` on a Raspberry Pi and confirm no pip cache warnings appear
- [ ] Verify the virtual environment and `[spi]` extras install successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)