### PR TITLE
fix: suppress pip cache warning in install_remoteterm_pi.sh

### DIFF
--- a/scripts/install_remoteterm_pi.sh
+++ b/scripts/install_remoteterm_pi.sh
@@ -44,8 +44,8 @@ fi
 echo "Activating virtualenv and installing Python dependencies (including [spi])..."
 # shellcheck disable=SC1090
 source "$VENV_DIR/bin/activate"
-pip install --upgrade pip
-pip install ".[spi]"
+pip install --no-cache-dir --upgrade pip
+pip install --no-cache-dir ".[spi]"
 
 echo
 echo "== Frontend (optional) =="


### PR DESCRIPTION
## Summary
- Previous fix (#36) covered \`manage_remoterm.sh\` but missed \`install_remoteterm_pi.sh\`
- Added \`--no-cache-dir\` to both \`pip install --upgrade pip\` and \`pip install ".[spi]"\` in the dev installer script
- Eliminates the \`/var/lib/remoteterm/.cache/pip\` permission warning when running as the service user

## Test plan

Tested on the Pi sandbox by simulating the \`remoteterm\` service user environment (HOME=/var/lib/remoteterm, which doesn't exist/isn't writable — matching the exact production condition).

**Without \`--no-cache-dir\` (main branch behaviour):**
\`\`\`
WARNING: The directory '/var/lib/remoteterm/.cache/pip' or its parent directory is not owned
or is not writable by the current user. The cache has been disabled. Check the permissions
and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
\`\`\`

**With \`--no-cache-dir\` (this fix):**
\`\`\`
no warning
\`\`\`

Bug reproduced on main, fix confirmed on the fix branch. Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)