### PR TITLE
chore: release v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.1] - 2026-04-22
+
+Bugfix: Suppress pip cache warning when installing as service user (manage_remoterm.sh, install_remoteterm_pi.sh)
+
 ## [3.2.0] - 2026-03-12
 
 Feature: Improve ambiguous-sender DM handling and visibility

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remoteterm-meshcore-frontend",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remoteterm-meshcore"
-version = "3.2.0"
+version = "3.2.1"
 description = "RemoteTerm - Web interface for MeshCore radio mesh networks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,7 +181,7 @@ class TestDebugEndpoint:
         with patch(
             "app.routers.debug._build_application_info",
             return_value=DebugApplicationInfo(
-                version="3.2.0",
+                version="3.2.1",
                 commit_hash="deadbeef",
                 git_branch="main",
                 git_dirty=False,
@@ -222,7 +222,7 @@ class TestDebugEndpoint:
         with patch(
             "app.routers.debug._build_application_info",
             return_value=DebugApplicationInfo(
-                version="3.2.0",
+                version="3.2.1",
                 commit_hash="deadbeef",
                 git_branch="main",
                 git_dirty=False,


### PR DESCRIPTION
## Summary
- Bumps version from 3.2.0 → 3.2.1
- Updates `pyproject.toml`, `frontend/package.json`, `tests/test_api.py`, and `CHANGELOG.md`

## Changes included in this release
- fix: suppress pip cache warning in `manage_remoterm.sh` (#36)
- fix: suppress pip cache warning in `install_remoteterm_pi.sh` (#37)

Both fixes were validated on a Raspberry Pi sandbox — bug reproduced on main, resolved with the fix.

Once merged, the "All Quality" CI → "Release build" workflow will automatically create the `v3.2.1` GitHub Release with the backend bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)