### PR TITLE
fix: PATCH /radio/config routed to wrong handler (no toast on save)

### DIFF
--- a/app/routers/radio.py
+++ b/app/routers/radio.py
@@ -118,12 +118,12 @@ async def get_radio_config() -> RadioConfigResponse:
     )
 
 
-@router.patch("/config", response_model=RadioConfigResponse)
 def _meshcore_from_backend(be):
     """Return the underlying MeshCore for command services; ClientBackend has _mc, SpiBackend is passed through."""
     return getattr(be, "_mc", be)
 
 
+@router.patch("/config", response_model=RadioConfigResponse)
 async def update_radio_config(update: RadioConfigUpdate) -> RadioConfigResponse:
     """Update radio configuration. Only provided fields will be updated."""
     require_connected()


### PR DESCRIPTION
## Summary
  - `@router.patch("/config")` was placed above the helper `_meshcore_from_backend` instead of
   the actual route handler `update_radio_config`
  - FastAPI was routing all `PATCH /radio/config` calls to the wrong function → 422 response
  - `handleSave` caught the error silently; `toast.success('Radio config saved')` was never
  reached

  ## Fix
  Moved the decorator one function down to `update_radio_config` where it belongs.

  ## Test
  E2E test `specs/zz-radio-settings.spec.ts` covers this — it clicks Save and asserts the
  toast appears.

  Closes #44
