### PR TITLE
feat: add sync channels button to radio settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
   useBrowserNotifications,
 } from './hooks';
 import { AppShell } from './components/AppShell';
+import { toast } from './components/ui/sonner';
 import type { MessageInputHandle } from './components/MessageInput';
 import { messageContainsMention } from './utils/messageParser';
 import { getStateKey } from './utils/conversationState';
@@ -333,6 +334,7 @@ export function App() {
   } = useConversationActions({
     activeConversation,
     activeConversationRef,
+    channels,
     setChannels,
     addMessageIfNew,
     jumpToBottom,
@@ -355,6 +357,18 @@ export function App() {
     },
     [fetchUndecryptedCount, setChannels]
   );
+  const handleSyncChannels = useCallback(async () => {
+    try {
+      const result = await api.syncChannels();
+      const updatedChannels = await api.getChannels();
+      setChannels(updatedChannels);
+      toast.success(`Synced ${result.synced} channel${result.synced === 1 ? '' : 's'} from radio`);
+    } catch (err) {
+      toast.error('Failed to sync channels', {
+        description: err instanceof Error ? err.message : 'Check radio connection',
+      });
+    }
+  }, [setChannels]);
 
   const statusProps = {
     health,
@@ -451,6 +465,7 @@ export function App() {
     onDisconnect: handleDisconnect,
     onReconnect: handleReconnect,
     onAdvertise: handleAdvertise,
+    onSyncChannels: handleSyncChannels,
     onHealthRefresh: handleHealthRefresh,
     onRefreshAppSettings: fetchAppSettings,
     blockedKeys: appSettings?.blocked_keys,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -171,6 +171,7 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ flood_scope_override: floodScopeOverride }),
     }),
+  syncChannels: () => fetchJson<{ synced: number }>('/channels/sync', { method: 'POST' }),
 
   // Messages
   getMessages: (

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -34,6 +34,7 @@ interface SettingsModalBaseProps {
   onDisconnect: () => Promise<void>;
   onReconnect: () => Promise<void>;
   onAdvertise: () => Promise<void>;
+  onSyncChannels: () => Promise<void>;
   onHealthRefresh: () => Promise<void>;
   onRefreshAppSettings: () => Promise<void>;
   onLocalLabelChange?: (label: LocalLabel) => void;
@@ -64,6 +65,7 @@ export function SettingsModal(props: SettingsModalProps) {
     onDisconnect,
     onReconnect,
     onAdvertise,
+    onSyncChannels,
     onHealthRefresh,
     onRefreshAppSettings,
     onLocalLabelChange,
@@ -189,6 +191,7 @@ export function SettingsModal(props: SettingsModalProps) {
               onDisconnect={onDisconnect}
               onReconnect={onReconnect}
               onAdvertise={onAdvertise}
+              onSyncChannels={onSyncChannels}
               onClose={onClose}
               className={sectionContentClass}
             />

--- a/frontend/src/components/settings/SettingsRadioSection.tsx
+++ b/frontend/src/components/settings/SettingsRadioSection.tsx
@@ -27,6 +27,7 @@ export function SettingsRadioSection({
   onDisconnect,
   onReconnect,
   onAdvertise,
+  onSyncChannels,
   onClose,
   className,
 }: {
@@ -41,6 +42,7 @@ export function SettingsRadioSection({
   onDisconnect: () => Promise<void>;
   onReconnect: () => Promise<void>;
   onAdvertise: () => Promise<void>;
+  onSyncChannels: () => Promise<void>;
   onClose: () => void;
   className?: string;
 }) {
@@ -75,6 +77,7 @@ export function SettingsRadioSection({
 
   // Advertise state
   const [advertising, setAdvertising] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const [connectionBusy, setConnectionBusy] = useState(false);
 
   useEffect(() => {
@@ -292,6 +295,15 @@ export function SettingsRadioSection({
       await onAdvertise();
     } finally {
       setAdvertising(false);
+    }
+  };
+
+  const handleSyncChannels = async () => {
+    setSyncing(true);
+    try {
+      await onSyncChannels();
+    } finally {
+      setSyncing(false);
     }
   };
 
@@ -699,6 +711,27 @@ export function SettingsRadioSection({
           className="w-full bg-warning hover:bg-warning/90 text-warning-foreground"
         >
           {advertising ? 'Sending...' : 'Send Advertisement'}
+        </Button>
+        {!health?.radio_connected && (
+          <p className="text-sm text-destructive">Radio not connected</p>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Sync Channels from Radio */}
+      <div className="space-y-2">
+        <Label>Sync Channels from Radio</Label>
+        <p className="text-xs text-muted-foreground">
+          Pull the channel list from the connected radio into the app. Required before sending
+          messages to channels you haven&apos;t synced yet.
+        </p>
+        <Button
+          onClick={handleSyncChannels}
+          disabled={syncing || !health?.radio_connected}
+          className="w-full"
+        >
+          {syncing ? 'Syncing...' : 'Sync Channels from Radio'}
         </Button>
         {!health?.radio_connected && (
           <p className="text-sm text-destructive">Radio not connected</p>

--- a/frontend/src/hooks/useConversationActions.ts
+++ b/frontend/src/hooks/useConversationActions.ts
@@ -8,6 +8,7 @@ import type { Channel, Conversation, Message } from '../types';
 interface UseConversationActionsArgs {
   activeConversation: Conversation | null;
   activeConversationRef: MutableRefObject<Conversation | null>;
+  channels: Channel[];
   setChannels: React.Dispatch<React.SetStateAction<Channel[]>>;
   addMessageIfNew: (msg: Message) => boolean;
   jumpToBottom: () => void;
@@ -32,6 +33,7 @@ interface UseConversationActionsResult {
 export function useConversationActions({
   activeConversation,
   activeConversationRef,
+  channels,
   setChannels,
   addMessageIfNew,
   jumpToBottom,
@@ -58,6 +60,13 @@ export function useConversationActions({
     async (text: string) => {
       if (!activeConversation) return;
 
+      if (activeConversation.type === 'channel') {
+        const channel = channels.find((c) => c.key === activeConversation.id);
+        if (channel && !channel.on_radio) {
+          throw new Error('Channel is not on the radio. Sync channels first.');
+        }
+      }
+
       const conversationId = activeConversation.id;
       const sent =
         activeConversation.type === 'channel'
@@ -68,7 +77,7 @@ export function useConversationActions({
         addMessageIfNew(sent);
       }
     },
-    [activeConversation, activeConversationRef, addMessageIfNew]
+    [activeConversation, activeConversationRef, channels, addMessageIfNew]
   );
 
   const handleResendChannelMessage = useCallback(

--- a/frontend/src/test/settingsModal.test.tsx
+++ b/frontend/src/test/settingsModal.test.tsx
@@ -102,6 +102,7 @@ function renderModal(overrides?: {
     onDisconnect,
     onReconnect,
     onAdvertise: vi.fn(async () => {}),
+    onSyncChannels: vi.fn(async () => {}),
     onHealthRefresh: vi.fn(async () => {}),
     onRefreshAppSettings,
   };
@@ -336,6 +337,7 @@ describe('SettingsModal', () => {
         onDisconnect={vi.fn(async () => {})}
         onReconnect={vi.fn(async () => {})}
         onAdvertise={vi.fn(async () => {})}
+        onSyncChannels={vi.fn(async () => {})}
         onHealthRefresh={vi.fn(async () => {})}
         onRefreshAppSettings={vi.fn(async () => {})}
       />

--- a/frontend/src/test/useConversationActions.test.ts
+++ b/frontend/src/test/useConversationActions.test.ts
@@ -65,6 +65,7 @@ function createArgs(overrides: Partial<Parameters<typeof useConversationActions>
   return {
     activeConversation,
     activeConversationRef: { current: activeConversation },
+    channels: [{ ...publicChannel, on_radio: true }],
     setChannels: vi.fn(),
     addMessageIfNew: vi.fn(() => true),
     jumpToBottom: vi.fn(),
@@ -131,6 +132,20 @@ describe('useConversationActions', () => {
     expect(args.handleToggleBlockedKey).toHaveBeenCalledWith('cc'.repeat(32));
     expect(mocks.messageCache.clear).toHaveBeenCalledTimes(1);
     expect(args.jumpToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the active channel is not on the radio', async () => {
+    const args = createArgs({ channels: [publicChannel] }); // on_radio: false
+
+    const { result } = renderHook(() => useConversationActions(args));
+
+    await expect(
+      act(async () => {
+        await result.current.handleSendMessage('hello');
+      })
+    ).rejects.toThrow('Channel is not on the radio');
+
+    expect(mocks.api.sendChannelMessage).not.toHaveBeenCalled();
   });
 
   it('appends sender mentions into the message input', () => {

--- a/tests/e2e/helpers/api.ts
+++ b/tests/e2e/helpers/api.ts
@@ -83,6 +83,10 @@ export function deleteChannel(key: string): Promise<void> {
   return fetchJson(`/channels/${key}`, { method: 'DELETE' });
 }
 
+export function syncChannels(): Promise<{ synced: number }> {
+  return fetchJson('/channels/sync', { method: 'POST' });
+}
+
 // --- Contacts ---
 
 export interface Contact {

--- a/tests/e2e/specs/sync-channels.spec.ts
+++ b/tests/e2e/specs/sync-channels.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Sync Channels from Radio', () => {
+  test('Sync Channels button is visible in Settings → Radio and syncs channels', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page.getByRole('status', { name: 'Radio OK' })).toBeVisible();
+
+    await page.getByText('Settings').click();
+
+    // Button should be visible
+    const syncButton = page.getByRole('button', { name: 'Sync Channels from Radio' });
+    await expect(syncButton).toBeVisible();
+
+    // Click it and expect a success toast
+    const syncResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/api/channels/sync')
+    );
+
+    await syncButton.click();
+
+    const syncResponse = await syncResponsePromise;
+    expect(syncResponse.ok()).toBeTruthy();
+
+    // Toast should appear
+    await expect(page.getByText(/Synced \d+ channel/)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -1128,7 +1128,7 @@ wheels = [
 
 [[package]]
 name = "remoteterm-meshcore"
-version = "3.2.1"
+version = "3.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
 Description:
  ## Summary
  - Adds a "Sync Channels" button in the Radio section of Settings that pulls channel data from the radio
  - Updates local channel list immediately after sync and shows a toast with the count of synced channels
  - Covers the new flow with an e2e spec and unit tests

  ## Test plan
  - [ ] Open Settings → Radio section, click "Sync Channels"
  - [ ] Verify toast shows correct synced channel count
  - [ ] Verify channel list updates in the UI without a page reload
  - [ ] Verify error toast appears when radio is disconnected