### PR TITLE
fix(spi): fix uConsole AIO v2 SPI TX failure and repeater ops

### DIFF
--- a/app/backends/spi_backend.py
+++ b/app/backends/spi_backend.py
@@ -970,6 +970,16 @@ class SpiBackend(RadioBackend):
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found"})
         result = await self._send_login(contact_name, password)
+
+        # Callers (e.g. repeaters.py's prepare_repeater_connection) subscribe to
+        # LOGIN_SUCCESS/LOGIN_FAILED filtered by pubkey_prefix *before* calling
+        # send_login and await that event rather than this return value directly
+        # (matching how ClientBackend's fire-and-forget send_login works). Emit
+        # it here so that flow resolves instead of always timing out.
+        pubkey_prefix = public_key[:12].lower()
+        event_type = EventType.LOGIN_SUCCESS if result.get("success") else EventType.LOGIN_FAILED
+        await self._event_bus.emit(event_type, {"pubkey_prefix": pubkey_prefix, **result})
+
         return _Event(EventType.LOGIN_SUCCESS, result)
 
     async def _send_protocol_request(
@@ -1231,13 +1241,14 @@ class SpiBackend(RadioBackend):
         timeout: int = 10,
         min_timeout: int = 5,
     ) -> Any:
-        from meshcore import EventType
-
+        # Matches meshcore's own req_status_sync: returns the plain payload
+        # dict (or None on failure), not an _Event wrapper -- callers (e.g.
+        # repeaters.py) call .get() directly on the return value.
         if not self._node:
-            return _Event(EventType.ERROR, {"error": "Not connected"})
+            return None
         contact_name = self._resolve_name(public_key)
         if not contact_name:
-            return _Event(EventType.ERROR, {"error": "Contact not found"})
+            return None
         # Prefer a binary REQ protocol request here. If we rely on higher-level
         # helpers that may be implemented as text/CLI on some pymc_core
         # versions/firmware builds, the repeater may respond with:
@@ -1321,11 +1332,10 @@ class SpiBackend(RadioBackend):
                 "direct_dups": raw_stats.get("n_direct_dups", 0),
                 "full_evts": raw_stats.get("err_events", 0),
             }
-            return _Event(EventType.STATUS_RESPONSE, mapped)
+            return mapped
 
         # Last-resort fallback: use the helper on the pymc_core node object.
-        result = await self._send_repeater_command(contact_name, "status")
-        return _Event(EventType.STATUS_RESPONSE, result)
+        return await self._send_repeater_command(contact_name, "status")
 
     async def req_telemetry_sync(
         self,
@@ -1333,15 +1343,19 @@ class SpiBackend(RadioBackend):
         timeout: int = 10,
         min_timeout: int = 5,
     ) -> Any:
-        from meshcore import EventType
-
+        # Matches meshcore's own req_telemetry_sync: returns the list of
+        # decoded CayenneLPP sensor entries directly (or None), not an _Event
+        # wrapper -- callers (e.g. repeaters.py) iterate the return value.
         if not self._node:
-            return _Event(EventType.ERROR, {"error": "Not connected"})
+            return None
         contact_name = self._resolve_name(public_key)
         if not contact_name:
-            return _Event(EventType.ERROR, {"error": "Contact not found"})
+            return None
         result = await self._send_telemetry_request(contact_name, timeout=timeout)
-        return _Event(EventType.TELEMETRY_RESPONSE, result)
+        telemetry_data = result.get("telemetry_data")
+        if isinstance(telemetry_data, dict):
+            return telemetry_data.get("sensors")
+        return None
 
     async def fetch_all_neighbours(
         self,
@@ -1494,8 +1508,22 @@ class SpiBackend(RadioBackend):
     # Events / subscriptions
     # ------------------------------------------------------------------
 
-    def subscribe(self, event_type: Any, handler: Any) -> Any:
-        return self._event_bus.subscribe(event_type, handler)
+    def subscribe(
+        self,
+        event_type: Any,
+        handler: Any,
+        attribute_filters: dict[str, Any] | None = None,
+    ) -> Any:
+        if not attribute_filters:
+            return self._event_bus.subscribe(event_type, handler)
+
+        def _filtered_handler(event: _Event) -> Any:
+            for key, val in attribute_filters.items():
+                if event.payload.get(key) != val:
+                    return None
+            return handler(event)
+
+        return self._event_bus.subscribe(event_type, _filtered_handler)
 
     # ------------------------------------------------------------------
     # Backend-specific helpers

--- a/app/backends/spi_backend.py
+++ b/app/backends/spi_backend.py
@@ -451,6 +451,161 @@ class SpiBackend(RadioBackend):
     # Messaging
     # ------------------------------------------------------------------
 
+    async def _send_text(
+        self,
+        contact_name: str,
+        message: str,
+        attempt: int = 1,
+        message_type: str = "direct",
+        out_path: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_text(); rebuilt here from the
+        pre-1.0.10 implementation using PacketBuilder + dispatcher.send_packet
+        directly. Return shape matches the old method exactly (success/attempt/
+        message_type/out_path/snr/rssi/crc) so callers are unaffected.
+        """
+        from pymc_core.protocol import PacketBuilder
+
+        contact = self._contact_store.get_by_name(contact_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {contact_name}")
+
+        pkt, ack_crc = PacketBuilder.create_text_message(
+            contact=contact,
+            local_identity=self._identity,
+            message=message,
+            attempt=attempt,
+            message_type=message_type,
+            out_path=out_path,
+        )
+
+        success = await self._node.dispatcher.send_packet(
+            pkt, wait_for_ack=True, expected_crc=ack_crc
+        )
+        if not success:
+            logger.warning("No ACK received for CRC %08X", ack_crc)
+
+        snr = getattr(pkt, "snr", None)
+        rssi = self._radio.get_last_rssi() if hasattr(self._radio, "get_last_rssi") else None
+        if snr is None and hasattr(self._radio, "get_last_snr"):
+            snr = self._radio.get_last_snr()
+
+        return {
+            "success": success,
+            "attempt": attempt,
+            "message_type": message_type,
+            "out_path": out_path,
+            "snr": snr,
+            "rssi": rssi,
+            "crc": ack_crc,
+        }
+
+    async def _send_repeater_command(
+        self,
+        repeater_name: str,
+        command: str,
+        parameters: str | None = None,
+    ) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_repeater_command(); rebuilt here
+        from the pre-1.0.10 implementation. Sends a text command to a repeater and
+        waits for a text response via the shared TextMessageHandler's command-response
+        callback. Return shape matches the old method exactly.
+        """
+        from pymc_core.protocol import PacketBuilder
+
+        contact = self._contact_store.get_by_name(repeater_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {repeater_name}")
+
+        start_time = time.time()
+        full_command = f"{command} {parameters}" if parameters else command
+
+        response_event = asyncio.Event()
+        response_data: dict[str, Any] = {"text": None}
+
+        def response_callback(message_text: str, sender_contact: Any) -> None:
+            response_data["text"] = message_text
+            response_event.set()
+
+        text_handler = self._node.dispatcher.text_message_handler
+        text_handler.set_command_response_callback(response_callback)
+        try:
+            pkt, ack_crc = PacketBuilder.create_text_message(
+                contact=contact,
+                local_identity=self._identity,
+                message=full_command,
+                attempt=1,
+                message_type="command",
+            )
+            ack_success = await self._node.dispatcher.send_packet(
+                pkt, wait_for_ack=True, expected_crc=ack_crc
+            )
+
+            try:
+                await asyncio.wait_for(response_event.wait(), timeout=15.0)
+                response_received = True
+            except TimeoutError:
+                response_received = False
+
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+            response_text = response_data["text"]
+
+            if response_received:
+                return {
+                    "success": True,
+                    "repeater": repeater_name,
+                    "command": command,
+                    "parameters": parameters,
+                    "full_command": full_command,
+                    "response": response_text,
+                    "rtt_ms": rtt_ms,
+                    "crc": ack_crc,
+                    "ack_received": ack_success,
+                    "reason": f"Command '{command}' successful with response"
+                    + ("" if ack_success else " (no ACK)"),
+                }
+            if ack_success:
+                return {
+                    "success": True,
+                    "repeater": repeater_name,
+                    "command": command,
+                    "parameters": parameters,
+                    "full_command": full_command,
+                    "response": "Command sent successfully (no response received)",
+                    "rtt_ms": rtt_ms,
+                    "crc": ack_crc,
+                    "ack_received": True,
+                    "reason": f"Command '{command}' sent but no response received",
+                }
+            return {
+                "success": False,
+                "repeater": repeater_name,
+                "command": command,
+                "parameters": parameters,
+                "full_command": full_command,
+                "response": None,
+                "rtt_ms": rtt_ms,
+                "crc": ack_crc,
+                "ack_received": False,
+                "reason": f"No ACK or response received for command '{command}'",
+            }
+        except Exception as e:
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+            return {
+                "success": False,
+                "repeater": repeater_name,
+                "command": command,
+                "parameters": parameters,
+                "full_command": full_command,
+                "response": None,
+                "rtt_ms": rtt_ms,
+                "crc": None,
+                "ack_received": False,
+                "reason": f"Error sending command: {e}",
+            }
+        finally:
+            text_handler.set_command_response_callback(None)
+
     async def send_msg(
         self,
         dst: Any,
@@ -465,7 +620,7 @@ class SpiBackend(RadioBackend):
             return _Event(EventType.ERROR, {"error": "Not connected"})
 
         contact_name = getattr(dst, "name", None) or str(dst)
-        result = await self._node.send_text(contact_name, msg)
+        result = await self._send_text(contact_name, msg)
 
         ack_crc = result.get("crc", 0)
         # meshcore uses MSG_SENT for successful send acknowledgements; mirror that here
@@ -492,7 +647,7 @@ class SpiBackend(RadioBackend):
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found"})
 
-        result = await self._node.send_repeater_command(contact_name, cmd)
+        result = await self._send_repeater_command(contact_name, cmd)
         # meshcore's EventType enum does not define CMD_RESPONSE in all versions.
         # For SPI mode we already have the full response dict from pymc_core, so
         # return OK and let the router decide whether it needs to wait for a
@@ -519,11 +674,26 @@ class SpiBackend(RadioBackend):
             if 0 <= chan < len(channels):
                 group_name = channels[chan]["name"]
         if group_name:
-            # send_group_text is fire-and-forget (no ACK expected). Scheduling it
-            # as a background task lets the API return immediately so the message
-            # appears in the UI without waiting for LBT + transmission (~5-15s).
+            # pymc_core >=1.0.10 dropped MeshNode.send_group_text(); build and send
+            # the group datagram directly the same way it did internally, matching
+            # the send_advert pattern below.
+            from pymc_core.protocol import PacketBuilder
+
+            pkt = PacketBuilder.create_group_datagram(
+                group_name=group_name,
+                local_identity=self._identity,
+                message=msg,
+                sender_name=self._self_info.get("adv_name", "RemoteTerm")
+                if self._self_info
+                else "RemoteTerm",
+                channels_config=self._channel_db.get_channels(),
+            )
+
+            # Fire-and-forget (no ACK expected). Scheduling it as a background task
+            # lets the API return immediately so the message appears in the UI
+            # without waiting for LBT + transmission (~5-15s).
             asyncio.create_task(
-                self._node.send_group_text(group_name, msg),
+                self._node.dispatcher.send_packet(pkt, wait_for_ack=False),
                 name=f"spi-group-send-{chan}",
             )
             return _Event(EventType.MSG_SENT, {"success": True})
@@ -721,6 +891,75 @@ class SpiBackend(RadioBackend):
     # Repeater operations
     # ------------------------------------------------------------------
 
+    async def _send_login(self, repeater_name: str, password: str) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_login(); rebuilt here from the
+        pre-1.0.10 implementation using the dispatcher's login_response_handler
+        directly (same handler CompanionBase._get_login_response_handler() returns).
+        """
+        from pymc_core.protocol import PacketBuilder
+
+        contact = self._contact_store.get_by_name(repeater_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {repeater_name}")
+
+        start_time = time.time()
+        contact_pubkey = bytes.fromhex(contact.public_key)
+        dest_hash = contact_pubkey[0] if len(contact_pubkey) > 0 else 0
+
+        login_handler = self._node.dispatcher.login_response_handler
+        login_handler.store_login_password(dest_hash, password)
+
+        login_result: dict[str, Any] = {"success": False, "data": {}}
+        login_event = asyncio.Event()
+
+        def login_response_callback(success: bool, response_data: dict) -> None:
+            login_result["success"] = success
+            login_result["data"] = response_data
+            login_event.set()
+
+        login_handler.set_login_callback(login_response_callback)
+        try:
+            pkt = PacketBuilder.create_login_packet(
+                contact=contact, local_identity=self._identity, password=password
+            )
+            await self._node.dispatcher.send_packet(pkt, wait_for_ack=False)
+
+            try:
+                await asyncio.wait_for(login_event.wait(), timeout=10.0)
+            except TimeoutError:
+                logger.warning("Login timeout for repeater %r", repeater_name)
+                return {
+                    "success": False,
+                    "repeater": repeater_name,
+                    "command": "login",
+                    "rtt_ms": round((time.time() - start_time) * 1000, 2),
+                    "reason": "Login response timeout",
+                }
+
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+            success = login_result["success"]
+            response_data = login_result["data"]
+
+            if success:
+                reason = (
+                    f"Login successful - Admin: {'Yes' if response_data.get('is_admin') else 'No'}"
+                )
+            else:
+                reason = f"Login failed: {response_data.get('error', 'Login failed')}"
+
+            return {
+                "success": success,
+                "repeater": repeater_name,
+                "command": "login",
+                "rtt_ms": rtt_ms,
+                "is_admin": response_data.get("is_admin", False),
+                "keep_alive_interval": response_data.get("keep_alive_interval", 0),
+                "reason": reason,
+            }
+        finally:
+            login_handler.set_login_callback(None)
+            login_handler.clear_login_password(dest_hash)
+
     async def send_login(self, public_key: str, password: str) -> Any:
         from meshcore import EventType
 
@@ -730,8 +969,261 @@ class SpiBackend(RadioBackend):
         contact_name = self._resolve_name(public_key)
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found"})
-        result = await self._node.send_login(contact_name, password)
+        result = await self._send_login(contact_name, password)
         return _Event(EventType.LOGIN_SUCCESS, result)
+
+    async def _send_protocol_request(
+        self,
+        repeater_name: str,
+        protocol_code: int,
+        data: bytes = b"",
+        timeout: float = 10.0,
+    ) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_protocol_request(); rebuilt here
+        from the pre-1.0.10 implementation using the dispatcher's
+        protocol_response_handler directly.
+        """
+        from pymc_core.protocol import PacketBuilder
+
+        contact = self._contact_store.get_by_name(repeater_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {repeater_name}")
+
+        start_time = time.time()
+        contact_hash = bytes.fromhex(contact.public_key)[0]
+
+        proto_handler = self._node.dispatcher.protocol_response_handler
+        if proto_handler is None:
+            raise RuntimeError("Protocol response handler not available")
+
+        response_event = asyncio.Event()
+        response_data: dict[str, Any] = {"success": False, "text": None, "parsed": {}}
+
+        def response_callback(success: bool, text: str, parsed_data: dict | None = None) -> None:
+            response_data["success"] = success
+            response_data["text"] = text
+            response_data["parsed"] = parsed_data or {}
+            response_event.set()
+
+        proto_handler.set_response_callback(contact_hash, response_callback)
+        try:
+            pkt, _ = PacketBuilder.create_protocol_request(
+                contact=contact,
+                local_identity=self._identity,
+                protocol_code=protocol_code,
+                data=data,
+            )
+            await self._node.dispatcher.send_packet(pkt, wait_for_ack=False)
+
+            try:
+                await asyncio.wait_for(response_event.wait(), timeout=timeout)
+                timed_out = False
+            except TimeoutError:
+                timed_out = True
+
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+
+            if timed_out:
+                return {
+                    "success": False,
+                    "repeater": repeater_name,
+                    "command": f"protocol_0x{protocol_code:02X}",
+                    "protocol_code": protocol_code,
+                    "response": None,
+                    "parsed_data": {},
+                    "rtt_ms": rtt_ms,
+                    "ack_received": False,
+                    "reason": f"Protocol 0x{protocol_code:02X} timeout",
+                }
+
+            return {
+                "success": response_data["success"],
+                "repeater": repeater_name,
+                "command": f"protocol_0x{protocol_code:02X}",
+                "protocol_code": protocol_code,
+                "response": response_data["text"],
+                "parsed_data": response_data["parsed"],
+                "rtt_ms": rtt_ms,
+                "ack_received": False,
+                "reason": (
+                    f"Protocol 0x{protocol_code:02X} "
+                    + ("successful" if response_data["success"] else "failed")
+                ),
+            }
+        finally:
+            proto_handler.clear_response_callback(contact_hash)
+
+    async def _send_telemetry_request(
+        self,
+        contact_name: str,
+        want_base: bool = True,
+        want_location: bool = True,
+        want_environment: bool = True,
+        timeout: float = 10.0,
+    ) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_telemetry_request(); rebuilt
+        here from the pre-1.0.10 implementation.
+        """
+        from pymc_core.protocol import PacketBuilder
+        from pymc_core.protocol.constants import REQ_TYPE_GET_TELEMETRY_DATA
+
+        contact = self._contact_store.get_by_name(contact_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {contact_name}")
+
+        start_time = time.time()
+        contact_hash = bytes.fromhex(contact.public_key)[0]
+
+        proto_handler = self._node.dispatcher.protocol_response_handler
+        if proto_handler is None:
+            raise RuntimeError("Protocol response handler not available")
+
+        response_event = asyncio.Event()
+        response_data: dict[str, Any] = {"success": False, "text": None, "parsed": {}}
+
+        def response_callback(success: bool, text: str, parsed_data: dict | None = None) -> None:
+            response_data["success"] = success
+            response_data["text"] = text
+            response_data["parsed"] = parsed_data or {}
+            response_event.set()
+
+        proto_handler.set_response_callback(contact_hash, response_callback)
+        try:
+            inv = PacketBuilder._compute_inverse_perm_mask(
+                want_base, want_location, want_environment
+            )
+            pkt, _ = PacketBuilder.create_protocol_request(
+                contact=contact,
+                local_identity=self._identity,
+                protocol_code=REQ_TYPE_GET_TELEMETRY_DATA,
+                data=bytes([inv]),
+            )
+            await self._node.dispatcher.send_packet(pkt, wait_for_ack=False)
+
+            try:
+                await asyncio.wait_for(response_event.wait(), timeout=timeout)
+                timed_out = False
+            except TimeoutError:
+                timed_out = True
+
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+            requested = {
+                "base": want_base,
+                "location": want_location,
+                "environment": want_environment,
+            }
+
+            if timed_out:
+                return {
+                    "success": False,
+                    "contact": contact_name,
+                    "requested": requested,
+                    "telemetry_data": None,
+                    "rtt_ms": rtt_ms,
+                    "reason": f"Telemetry response timeout after {timeout}s",
+                }
+
+            return {
+                "success": response_data["success"],
+                "contact": contact_name,
+                "requested": requested,
+                "telemetry_data": response_data["parsed"],
+                "response_text": response_data["text"],
+                "rtt_ms": rtt_ms,
+                "reason": "Telemetry response received"
+                if response_data["success"]
+                else "Telemetry request failed",
+            }
+        finally:
+            proto_handler.clear_response_callback(contact_hash)
+
+    async def _send_trace_packet(
+        self,
+        contact_name: str,
+        tag: int,
+        auth_code: int,
+        flags: int = 0,
+        path: list[int] | None = None,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]:
+        """pymc_core >=1.0.10 dropped MeshNode.send_trace_packet(); rebuilt here
+        from the pre-1.0.10 implementation using the dispatcher's trace_handler.
+        """
+        from pymc_core.protocol import PacketBuilder
+
+        contact = self._contact_store.get_by_name(contact_name) if self._contact_store else None
+        if not contact:
+            raise RuntimeError(f"Contact not found: {contact_name}")
+
+        start_time = time.time()
+        target_node_id = bytes.fromhex(contact.public_key)[0]
+        trace_path = path if path else [target_node_id]
+
+        pkt = PacketBuilder.create_trace(tag, auth_code, flags, path=trace_path)
+        trace_data = {"tag": tag, "auth_code": auth_code, "flags": flags, "path": trace_path}
+
+        handler = self._node.dispatcher.trace_handler
+        if not handler:
+            return {
+                "success": False,
+                "contact": contact_name,
+                "reason": "No trace handler available",
+            }
+
+        contact_hash = target_node_id
+        response_event = asyncio.Event()
+        response_data: dict[str, Any] = {"success": True, "text": None, "parsed": {}}
+
+        def response_callback(success: bool, text: str, parsed_data: dict | None = None) -> None:
+            response_data["success"] = success
+            response_data["text"] = text
+            response_data["parsed"] = parsed_data or {}
+            response_event.set()
+
+        handler.set_response_callback(contact_hash, response_callback)
+        try:
+            await self._node.dispatcher.send_packet(pkt, wait_for_ack=False)
+
+            try:
+                await asyncio.wait_for(response_event.wait(), timeout=timeout)
+                timed_out = False
+            except TimeoutError:
+                timed_out = True
+
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+
+            if timed_out:
+                return {
+                    "success": False,
+                    "contact": contact_name,
+                    "trace_data": trace_data,
+                    "response": None,
+                    "rtt_ms": rtt_ms,
+                    "reason": f"Timeout after {timeout}s",
+                }
+
+            return {
+                "success": response_data["success"],
+                "contact": contact_name,
+                "trace_data": trace_data,
+                "response": response_data["text"],
+                "parsed_data": response_data["parsed"],
+                "rtt_ms": rtt_ms,
+                "reason": "Response received",
+            }
+        except Exception as e:
+            rtt_ms = round((time.time() - start_time) * 1000, 2)
+            logger.error("Trace error: %s", e)
+            return {
+                "success": False,
+                "contact": contact_name,
+                "trace_data": trace_data,
+                "response": None,
+                "rtt_ms": rtt_ms,
+                "reason": f"Error: {e}",
+            }
+        finally:
+            handler.clear_response_callback(contact_hash)
 
     async def req_status_sync(
         self,
@@ -764,7 +1256,7 @@ class SpiBackend(RadioBackend):
 
         raw_stats: dict[str, Any] | None = None
         try:
-            proto_result = await self._node.send_protocol_request(contact_name, protocol_code, b"")
+            proto_result = await self._send_protocol_request(contact_name, protocol_code, b"")
             if isinstance(proto_result, dict) and proto_result.get("success") is True:
                 # Different pymc_core versions may use slightly different field
                 # names for the parsed payload.
@@ -832,7 +1324,7 @@ class SpiBackend(RadioBackend):
             return _Event(EventType.STATUS_RESPONSE, mapped)
 
         # Last-resort fallback: use the helper on the pymc_core node object.
-        result = await self._node.send_status_request(contact_name)
+        result = await self._send_repeater_command(contact_name, "status")
         return _Event(EventType.STATUS_RESPONSE, result)
 
     async def req_telemetry_sync(
@@ -848,7 +1340,7 @@ class SpiBackend(RadioBackend):
         contact_name = self._resolve_name(public_key)
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found"})
-        result = await self._node.send_telemetry_request(contact_name, timeout=timeout)
+        result = await self._send_telemetry_request(contact_name, timeout=timeout)
         return _Event(EventType.TELEMETRY_RESPONSE, result)
 
     async def fetch_all_neighbours(
@@ -870,7 +1362,7 @@ class SpiBackend(RadioBackend):
             return {"error": "Contact not found"}
 
         try:
-            result = await self._node.send_repeater_command(contact_name, "neighbors")
+            result = await self._send_repeater_command(contact_name, "neighbors")
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("SPI neighbours command failed")
             return {"error": str(exc)}
@@ -936,7 +1428,7 @@ class SpiBackend(RadioBackend):
         if not contact_name:
             return _Event(EventType.ERROR, {"error": "Contact not found for trace"})
 
-        result = await self._node.send_trace_packet(contact_name, tag, auth_code=0)
+        result = await self._send_trace_packet(contact_name, tag, auth_code=0)
         return _Event(EventType.TRACE_DATA, result)
 
     async def wait_for_event(

--- a/app/backends/spi_config.py
+++ b/app/backends/spi_config.py
@@ -56,6 +56,13 @@ HARDWARE_PROFILES: dict[str, HardwareProfile] = {
         irq_pin=26,
         txen_pin=-1,
         rxen_pin=-1,
+        # Per HackerGadgets' own setup guide: DIO2_AS_RF_SWITCH and
+        # DIO3_TCXO_VOLTAGE must both be true for this board's SX1262.
+        # Without these the chip responds to basic SPI config commands but
+        # the RF frontend/TCXO clock reference is unstable, causing CAD/TX
+        # to fail (IRQ status reads returning 0xFFFF, no TX_DONE interrupt).
+        use_dio3_tcxo=True,
+        use_dio2_rf=True,
         prerequisites=[
             "Enable SPI and SPI1 overlay: add 'dtparam=spi=on' and "
             "'dtoverlay=spi1-1cs' to /boot/firmware/config.txt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ where = ["."]
 include = ["app*"]
 
 [project.optional-dependencies]
-spi = ["pymc_core[hardware]>=1.0.7,<1.0.10"]
+spi = ["pymc_core[hardware]>=1.0.12"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -1263,22 +1263,23 @@ wheels = [
 
 [[package]]
 name = "pymc-core"
-version = "1.0.7"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycryptodome" },
     { name = "pynacl" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/d8/182eb232d3d1ecaeacb2f2901ffd3dcb21893cfd7cf6b290ec0ab7c8bbb9/pymc_core-1.0.7.tar.gz", hash = "sha256:96eb511c2a8b7d739dfb73275dc737836414c97bc6fbc603ec1bf12fade2c90d", size = 129663, upload-time = "2026-01-12T21:51:45.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/c1/810e384ca0ebe77202c983ed1568d6ce79730eb0a908a99246315c48ca26/pymc_core-1.0.12.tar.gz", hash = "sha256:28ed891c9e268dab20eb682e061fd8d86b7f8706a2af91ea05f976f4b04b4c1f", size = 289269, upload-time = "2026-05-22T14:47:30.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/8c/ac0a82f9b5662e033dd77fdd607f950a2ca839822930d0e39bc13bf8f206/pymc_core-1.0.7-py3-none-any.whl", hash = "sha256:d8ca56ecb0b0da4cca15df1b5e53a6843d031b2ce08eda03166935407298634f", size = 131661, upload-time = "2026-01-12T21:51:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e8/03929b79cd53553103291a39f0121db6e04a755b0b7c6eedab8760e8675b/pymc_core-1.0.12-py3-none-any.whl", hash = "sha256:0ab8f9f12d2423810558ef8561ff301d2021d50c6b8216f8dc1f1db6fb3a8668", size = 259968, upload-time = "2026-05-22T14:47:29.191Z" },
 ]
 
 [package.optional-dependencies]
 hardware = [
     { name = "pyserial" },
     { name = "python-periphery" },
+    { name = "pyusb" },
     { name = "spidev" },
 ]
 
@@ -1491,6 +1492,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyusb"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6b/ce3727395e52b7b76dfcf0c665e37d223b680b9becc60710d4bc08b7b7cb/pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e", size = 77281, upload-time = "2025-01-08T23:45:01.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430", size = 58465, upload-time = "2025-01-08T23:45:00.029Z" },
+]
+
+[[package]]
 name = "pywebpush"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1607,7 +1617,7 @@ requires-dist = [
     { name = "meshcore", specifier = "==2.3.7" },
     { name = "pycryptodome", specifier = ">=3.20.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "pymc-core", extras = ["hardware"], marker = "extra == 'spi'", specifier = ">=1.0.7,<1.0.10" },
+    { name = "pymc-core", extras = ["hardware"], marker = "extra == 'spi'", specifier = ">=1.0.12" },
     { name = "pynacl", specifier = ">=1.5.0" },
     { name = "pywebpush", specifier = ">=0.14.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },


### PR DESCRIPTION
## Summary

Fixes the uConsole AIO v2 board's SPI radio never actually transmitting (`0xFFFF` IRQ status reads, silent TX failures masked as success), plus repeater login/status/telemetry bugs surfaced while verifying the fix on real hardware.

- **`pymc_core` bumped `1.0.7` → `1.0.12`** — the installed version was pinned below a fix for a hardcoded SPI1 chip-select workaround (`GPIO17` override for "ClockworkPi/Heltec boards") that corrupted SPI reads on this board. The `<1.0.10` upper bound had no documented reason (traced to a mechanical upstream-sync commit) and silently excluded every fixed release since `1.0.8`/`1.0.9` don't exist on PyPI.
- **Ported `SpiBackend` off `MeshNode`'s removed convenience API** — `1.0.10` also dropped `send_text`, `send_group_text`, `send_login`, `send_protocol_request`, `send_status_request`, `send_telemetry_request`, `send_repeater_command`, `send_trace_packet`. Rebuilt each as a private helper using `PacketBuilder` + `dispatcher.send_packet()` directly, referenced against `pymc_core.companion.companion_base.CompanionBase`'s own implementations for correct protocol/ACK-correlation logic. Return shapes match the removed methods exactly.
- **Enabled `use_dio3_tcxo`/`use_dio2_rf`** for the `uconsole` hardware profile — required per HackerGadgets' own AIO v2 setup guide and `pyMC_Repeater` PR #99; without these the chip responds to basic SPI config commands but the RF frontend/TCXO clock reference is unstable, causing CAD/TX to fail.
- **Fixed two pre-existing `SpiBackend` bugs** surfaced during first real SPI-mode repeater testing (not introduced by this migration, just never exercised before):
  - `subscribe()` didn't accept `attribute_filters`, crashing repeater login with a `TypeError`. `send_login()` now also emits `LOGIN_SUCCESS`/`LOGIN_FAILED` via the event bus so the router's subscribe-then-await flow actually resolves instead of always timing out.
  - `req_status_sync`/`req_telemetry_sync` returned `_Event`-wrapped results, but callers (`repeaters.py`, `rooms.py`, `contacts.py`) call `.get()`/iterate the return value directly, matching the real `meshcore` library's unwrapped return shape. Fixed to return the plain dict/sensor list (or `None`) directly.

## Known follow-up (not fixed here)

`send_trace` has a similar "router awaits a bus event separately from the return value" gap, but additionally needs real per-hop SNR parsing from `pymc_core`'s `TraceHandler` output that isn't currently available in the shape the router expects. Tracked separately, not blocking.

## Test plan

- [x] `./scripts/quality/all_quality.sh` — lint, pyright (153 files, 0 errors), 1600 backend tests, 774 frontend tests, frontend build all pass
- [x] USB serial regression check against a live RAK 4631 companion (`ClientBackend`, untouched by this change) — DM/channel/advert send and receive confirmed
- [x] Verified end-to-end on uConsole AIO v2 hardware (SPI mode): clean `TX_DONE` interrupts, channel message send/receive, advert send/receive, repeater login, repeater status, repeater telemetry — all confirmed against a live repeater